### PR TITLE
Issue #141 Wait 2 minutes for Sonar results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
         stage('Quality gate') {
             steps {
                 // Just in case something goes wrong, pipeline will be killed after a timeout
-                timeout(time: 1, unit: 'MINUTES') {
+                timeout(time: 2, unit: 'MINUTES') {
                     script {
                         def qg = waitForQualityGate()
                         if (qg.status != 'OK') {


### PR DESCRIPTION
Upping sonar timeout from 1 minute to 2, per #141.