### PR TITLE
Issue #91 - Log Exceptions in one line Log4j2

### DIFF
--- a/src/main/java/org/galatea/starter/domain/SettlementMission.java
+++ b/src/main/java/org/galatea/starter/domain/SettlementMission.java
@@ -16,7 +16,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
-/* For builder since we explictly want to make the all args ctor private */
+/* For builder since we explicitly want to make the all args ctor private */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE) // For spring and jackson
 @Builder

--- a/src/main/resources/log4j2-stdout.yml
+++ b/src/main/resources/log4j2-stdout.yml
@@ -15,7 +15,7 @@ Configuration:
       name: Console
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%n"
+        Pattern: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%nThrowable{separator(|)}"
           
   Loggers:
     # Define some defaults

--- a/src/main/resources/log4j2-stdout.yml
+++ b/src/main/resources/log4j2-stdout.yml
@@ -15,7 +15,7 @@ Configuration:
       name: Console
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%nThrowable{separator(|)}"
+        Pattern: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%n%xThrowable{separator(|)}"
           
   Loggers:
     # Define some defaults

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -34,8 +34,9 @@ Configuration:
         # Define where to put logs when rolling
         filePattern: ${log-archive-dir}/${log-file-prefix}.${zip-suffix}
         # Define what the log output will look like 
-        PatternLayout: 
-          Pattern: ${log-pattern}
+        PatternLayout:
+          # Log throwables (exceptions) on one line, split by the pipe delimiter
+          Pattern: ${log-pattern}%xThrowable{separator(|)}
         Policies:
           # Logs should be rolled based on time. Rolled logs should be gz (defined by zip-suffix)
           TimeBasedTriggeringPolicy:

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -35,9 +35,7 @@ Configuration:
         filePattern: ${log-archive-dir}/${log-file-prefix}.${zip-suffix}
         # Define what the log output will look like 
         PatternLayout:
-          # Log throwables (exceptions) on one line, split by the pipe delimiter (useful for the
-          # ELK stack, where we cannot guarantee the sequential writing of multiline logs)
-          Pattern: ${log-pattern}%xThrowable{separator(|)}
+          Pattern: ${log-pattern}
         Policies:
           # Logs should be rolled based on time. Rolled logs should be gz (defined by zip-suffix)
           TimeBasedTriggeringPolicy:
@@ -74,7 +72,9 @@ Configuration:
         filename: ${log-dir}/${log-file-prefix}.errors.log
         filePattern: ${log-archive-dir}/${log-file-prefix}.errors.${zip-suffix}
         PatternLayout: 
-          Pattern: ${log-pattern}
+          # Log throwables (exceptions) on one line, split by the pipe delimiter (useful for the
+          # ELK stack, where we cannot guarantee the sequential writing of multiline logs)
+          Pattern: ${log-pattern}%xThrowable{separator(|)}
         Policies:
           TimeBasedTriggeringPolicy:
             interval: 1

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -36,7 +36,7 @@ Configuration:
         # Define what the log output will look like 
         PatternLayout:
           # Log throwables (exceptions) on one line, split by the pipe delimiter (useful for the
-          # ELK stack, where we cannot guarantee the seqeuential writing of logs)
+          # ELK stack, where we cannot guarantee the seqeuential writing of multiline logs)
           Pattern: ${log-pattern}%xThrowable{separator(|)}
         Policies:
           # Logs should be rolled based on time. Rolled logs should be gz (defined by zip-suffix)

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -20,8 +20,9 @@ Configuration:
         # ending the zip-suffix with .gz will cause rolled logs to get gzipped
       - name: zip-suffix
         value: "%d{yyyyMMdd.HH}.%i.log.gz"
+        # Log throwables (exceptions) on one line, split by the pipe delimiter
       - name: log-pattern
-        value: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%n"
+        value: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%n%xThrowable{separator(|)}"
 
 # Create some appenders
   Appenders:
@@ -71,10 +72,8 @@ Configuration:
       - name: ErrorRollingFileAppender
         filename: ${log-dir}/${log-file-prefix}.errors.log
         filePattern: ${log-archive-dir}/${log-file-prefix}.errors.${zip-suffix}
-        PatternLayout: 
-          # Log throwables (exceptions) on one line, split by the pipe delimiter (useful for the
-          # ELK stack, where we cannot guarantee the sequential writing of multiline logs)
-          Pattern: ${log-pattern}%xThrowable{separator(|)}
+        PatternLayout:
+          Pattern: ${log-pattern}
         Policies:
           TimeBasedTriggeringPolicy:
             interval: 1

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -35,7 +35,8 @@ Configuration:
         filePattern: ${log-archive-dir}/${log-file-prefix}.${zip-suffix}
         # Define what the log output will look like 
         PatternLayout:
-          # Log throwables (exceptions) on one line, split by the pipe delimiter
+          # Log throwables (exceptions) on one line, split by the pipe delimiter (useful for the
+          # ELK stack, where we cannot guarantee the seqeuential writing of logs)
           Pattern: ${log-pattern}%xThrowable{separator(|)}
         Policies:
           # Logs should be rolled based on time. Rolled logs should be gz (defined by zip-suffix)

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -36,7 +36,7 @@ Configuration:
         # Define what the log output will look like 
         PatternLayout:
           # Log throwables (exceptions) on one line, split by the pipe delimiter (useful for the
-          # ELK stack, where we cannot guarantee the seqeuential writing of multiline logs)
+          # ELK stack, where we cannot guarantee the sequential writing of multiline logs)
           Pattern: ${log-pattern}%xThrowable{separator(|)}
         Policies:
           # Logs should be rolled based on time. Rolled logs should be gz (defined by zip-suffix)

--- a/src/test/resources/log4j2-debug.yml
+++ b/src/test/resources/log4j2-debug.yml
@@ -14,7 +14,7 @@ Configuration:
       name: Console
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%n"
+        Pattern: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%nThrowable{separator(|)"
 
   Loggers:
 

--- a/src/test/resources/log4j2-debug.yml
+++ b/src/test/resources/log4j2-debug.yml
@@ -14,7 +14,7 @@ Configuration:
       name: Console
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%nThrowable{separator(|)"
+        Pattern: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%n%xThrowable{separator(|)}"
 
   Loggers:
 


### PR DESCRIPTION
Throwables in the now log on one line in file appenders and stdout (pipe delimited).

![one-line-log4j2-exceptions](https://user-images.githubusercontent.com/36625850/37083245-df5a7b1c-21e6-11e8-9ddb-9be7d9131b91.png)
