### PR TITLE
Set exception handler to use exception to string instead of exception message

### DIFF
--- a/src/main/java/org/galatea/starter/entrypoint/RestExceptionHandler.java
+++ b/src/main/java/org/galatea/starter/entrypoint/RestExceptionHandler.java
@@ -24,7 +24,7 @@ public class RestExceptionHandler {
 
   @ExceptionHandler(EntityNotFoundException.class)
   protected ResponseEntity<Object> handleEntityNotFound(final EntityNotFoundException exception) {
-    ApiError error = new ApiError(HttpStatus.NOT_FOUND, exception.getMessage());
+    ApiError error = new ApiError(HttpStatus.NOT_FOUND, exception.toString());
     return buildResponseEntity(error);
   }
 
@@ -59,7 +59,7 @@ public class RestExceptionHandler {
   protected ResponseEntity<Object> handleJsonProcessingException(
       final JsonProcessingException exception) {
     log.debug("Error converting to JSON", exception);
-    ApiError error = new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+    ApiError error = new ApiError(HttpStatus.INTERNAL_SERVER_ERROR, exception.toString());
     return buildResponseEntity(error);
   }
 


### PR DESCRIPTION
Changed exception handling to return error built on exception string instead of exception message which could be null. This resolves #235.