### PR TITLE
Renamed request threads to contain the internal request id

### DIFF
--- a/src/main/java/org/galatea/starter/utils/Tracer.java
+++ b/src/main/java/org/galatea/starter/utils/Tracer.java
@@ -227,6 +227,9 @@ public class Tracer {
       String internallyGeneratedId =
           Integer.toString(QUERY_ID_GENERATOR.nextInt(Integer.MAX_VALUE));
 
+      // set the thread name to the internal request id
+      Thread.currentThread().setName(INTERNAL_REQUEST_ID + "-" + internallyGeneratedId);
+
       // Add request id to Trace
       addTraceInfo(Tracer.class, INTERNAL_REQUEST_ID, internallyGeneratedId);
       log.debug("Created internal request id: {}", internallyGeneratedId);


### PR DESCRIPTION
Threads are now renamed to "internal-request-id-123456" immediately after internal request id creation in the Tracer class.  Addressed the other components this issue in the issue thread (#29).