### PR TITLE
Issue-253 Configure cache so EhCache is used instead of the default cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,20 @@
 			<artifactId>ehcache</artifactId>
 		</dependency>
 
+		<!-- Spring caching framework inside this -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>4.3.13.RELEASE</version>
+		</dependency>
+
+		<!-- Support for Ehcache and others -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+			<version>4.3.13.RELEASE</version>
+		</dependency>
+
     <dependency>
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-core</artifactId>

--- a/src/main/java/org/galatea/starter/AppConfig.java
+++ b/src/main/java/org/galatea/starter/AppConfig.java
@@ -4,16 +4,24 @@ import lombok.extern.slf4j.Slf4j;
 import net.sf.aspect4log.aspect.LogAspect;
 import org.galatea.starter.domain.SettlementMission;
 import org.galatea.starter.service.IAgreementTransformer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.core.io.ClassPathResource;
 
 @Slf4j
 @Configuration
 @EnableAspectJAutoProxy
 @EnableCaching
 public class AppConfig {
+
+  @Value("${cache-config}")
+  public String cacheConfig;
 
   @Bean
   public LogAspect createLogAspect() {
@@ -30,6 +38,22 @@ public class AppConfig {
     return agreement -> SettlementMission.builder().instrument(agreement.getInstrument())
         .externalParty(agreement.getExternalParty()).depot("DTC").qty(agreement.getQty())
         .direction("B".equals(agreement.getBuySell()) ? "REC" : "DEL").build();
+  }
 
+  /**
+   * CacheManager that contains the Cache Configuration. Spring will use this cache if any
+   * cache annotations are used.
+   */
+  @Bean
+  public CacheManager cacheManager() {
+    return new EhCacheCacheManager(ehCacheCacheManager().getObject());
+  }
+
+  @Bean
+  public EhCacheManagerFactoryBean ehCacheCacheManager() {
+    EhCacheManagerFactoryBean cmfb = new EhCacheManagerFactoryBean();
+    cmfb.setConfigLocation(new ClassPathResource(cacheConfig));
+    cmfb.setShared(true);
+    return cmfb;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ jms:
    listener-concurrency: 1-5
    agreement-queue-json: sandbox.agreement
    agreement-queue-proto: sandbox.agreement.proto
+cache-config: ehcache.xml
 ---
 # Test properties go here
 spring:


### PR DESCRIPTION
See #253.

The cache was not set up correctly and was using the default simple Spring implementation instead of the config in `ehcache.xml`. This PR fixes this so the `ehcache.xml` config is used.