### PR TITLE
Feature/issue-231 JPA CRUD operation examples #231

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ FUSE currently shows how to read from a queue (not a topic).
 `org.galatea.starter.JmsConfig` - is the spring java config related to jms
 `org.galatea.starter.entrypoint.SettlementJmsListenerTest` - shows you how to test a jms listener.  SpringBoot fires up an embedded ActiveMQ broker for the test.  It's important to look at the mentiod annotated with @After in ASpringTest.  You'll see that we tear down the jms connection after each test to ensure isolation between tests.  This is important.
 
+## JPA
+
+- **JPA (Java Persistence API)** is a Java specification for ORM (Object Relational Mapping) which is the process of converting objects to records in a relational database and vice versa. This abstracts developers from low level SQL code as well as the need to hand-map SQL result objects to Java POJOs.
+
+- **Hibernate** is an very popular implementation of the JPA specification that FUSE uses. It also offers other features not in the JPA specification. However, usage of these features will make it more challenging to switch to another JPA provider if needed.
+
+- **Spring Data** is a layer on top of a JPA provider that acts as an abstraction for JPA repositories to reduce boilerplate code. For example, Spring Data contains the `CrudRepository` interface which provides CRUD functionality, in very few lines of code, for an entity class being managed.
+
 ## Logging
 - For the main configuration see: src/main/resources/log4j2.yml 
 - For configuring logging to the console and selectively enabling debug logging for local testing see: src/test/resources/log4j2-debug.yml 

--- a/src/main/java/org/galatea/starter/domain/rpsy/ISettlementMissionRpsy.java
+++ b/src/main/java/org/galatea/starter/domain/rpsy/ISettlementMissionRpsy.java
@@ -1,6 +1,7 @@
 package org.galatea.starter.domain.rpsy;
 
 import org.galatea.starter.domain.SettlementMission;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.repository.CrudRepository;
 
@@ -8,10 +9,23 @@ import java.util.List;
 
 public interface ISettlementMissionRpsy extends CrudRepository<SettlementMission, Long> {
 
+  String MISSIONS_CACHE = "missions";
+
   List<SettlementMission> findByDepot(String depot);
 
   @Override
-  @Cacheable(cacheNames = "missions", sync = true)
+  @Cacheable(cacheNames = MISSIONS_CACHE, sync = true)
   SettlementMission findOne(Long id);
 
+  @Override
+  @CacheEvict(cacheNames = MISSIONS_CACHE)
+  void delete(Long id);
+
+  /**
+   * 'p0' required in key because java does not retain parameter names during compilation unless
+   * specified. You must use position parameter bindings otherwise.
+   */
+  @Override
+  @CacheEvict(cacheNames = MISSIONS_CACHE, key = "#p0.getId()")
+  <S extends SettlementMission> S save(S entity);
 }

--- a/src/main/java/org/galatea/starter/entrypoint/BaseSettlementRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/BaseSettlementRestController.java
@@ -42,4 +42,22 @@ public abstract class BaseSettlementRestController extends BaseRestController {
   protected Optional<SettlementMission> getMissionInternal(final Long id) {
     return settlementService.findMission(id);
   }
+
+  /**
+   * Updates settlement mission, if it exists, using the given agreement.
+   */
+  protected Optional<SettlementMission> updateMissionInternal(final Long id, final TradeAgreement agreement) {
+    if (settlementService.missionExists(id)) {
+      return settlementService.updateMission(id, agreement);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Deletes a settlement mission from the settlement service.
+   */
+  protected void deleteMissionInternal(final Long id) {
+    settlementService.deleteMission(id);
+  }
 }

--- a/src/main/java/org/galatea/starter/service/SettlementService.java
+++ b/src/main/java/org/galatea/starter/service/SettlementService.java
@@ -58,4 +58,38 @@ public class SettlementService {
   public Optional<SettlementMission> findMission(final Long id) {
     return Optional.ofNullable(missionrpsy.findOne(id));
   }
+
+  /**
+   * Update the mission with the ID using the given TradeAgreement.
+   *
+   * @param id identifier of the mission
+   * @param agreement the agreement used to update the mission to
+   * @return optional containing the saved mission
+   */
+  public Optional<SettlementMission> updateMission(final Long id, final TradeAgreement agreement) {
+    SettlementMission settlementMission = agreementTransformer.transform(agreement);
+    settlementMission.setId(id);
+    SettlementMission savedMission = missionrpsy.save(settlementMission);
+    log.info("The following mission was updated: {}", savedMission);
+    return Optional.ofNullable(savedMission);
+  }
+
+  /**
+   * @param id identifier of the mission
+   * @return does a mission with the id exist?
+   */
+  public boolean missionExists(final Long id) {
+    return missionrpsy.exists(id);
+  }
+
+  /**
+   * Delete the mission by ID.
+   * This removes the mission from the cache as well.
+   *
+   * @param id identifier of the mission to delete
+   */
+  public void deleteMission(final Long id) {
+    missionrpsy.delete(id);
+    log.info("Mission with id '{}' was deleted", id);
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,9 @@ spring:
       database-platform: org.hibernate.dialect.MySQLDialect
 mvc:
    settleMissionPath: /settlementEngine
+   updateMissionPath: /settlementEngine/mission/
    getMissionPath: /settlementEngine/mission/
+   deleteMissionPath: /settlementEngine/mission/
    max-size-trace-payload: 50000
 jms:
    listener-concurrency: 1-5

--- a/src/test/java/org/galatea/starter/entrypoint/SettlementRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/SettlementRestControllerTest.java
@@ -7,7 +7,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -46,6 +49,7 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -228,6 +232,26 @@ public class SettlementRestControllerTest extends ASpringTest {
         .andExpect(jsonPath("$.status", is(HttpStatus.INTERNAL_SERVER_ERROR.name())))
         .andExpect(jsonPath("$.message", is("An internal application error occurred.")));
   }
+
+  @Test
+  public void testDeleteMission() throws Exception {
+    doNothing().when(mockSettlementService).deleteMission(MISSION_ID_1);
+
+    this.mvc.perform(delete("/settlementEngine/mission/" + MISSION_ID_1 + "?requestId=1234")
+        .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  public void testDeleteFakeMission() throws Exception {
+    doThrow(EmptyResultDataAccessException.class).when(mockSettlementService)
+        .deleteMission(MISSION_ID_1);
+
+    this.mvc.perform(delete("/settlementEngine/mission/" + MISSION_ID_1 + "?requestId=1234")
+        .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isNotFound());
+  }
+
 
   /**
    * Verifies required audit fields are present

--- a/src/test/java/org/galatea/starter/service/SettlementServiceTest.java
+++ b/src/test/java/org/galatea/starter/service/SettlementServiceTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
 
 import org.galatea.starter.ASpringTest;
 import org.galatea.starter.domain.SettlementMission;
@@ -73,5 +75,50 @@ public class SettlementServiceTest extends ASpringTest {
 
     Set<Long> missionIds = service.spawnMissions(Collections.singletonList(testTradeAgreement));
     assertEquals(1, missionIds.size());
+  }
+
+  @Test
+  public void testUpdateMission() {
+
+    SettlementMission testSettlementMission = SettlementMission.builder().id(35L).depot("DTC")
+        .externalParty("EXT-1").instrument("IBM").direction("REC").qty(100d).build();
+
+    TradeAgreement testTradeAgreement = TradeAgreement.builder().id(45L).instrument("instr-1")
+        .internalParty("icp-1").externalParty("ecp-1").buySell("B").qty(4500.0).build();
+
+    given(mockAgreementTransformer.transform(any()))
+        .willReturn(testSettlementMission);
+    given(this.mockSettlementMissionRpsy.save(testSettlementMission))
+        .willReturn(testSettlementMission);
+
+    SettlementService service =
+        new SettlementService(this.mockSettlementMissionRpsy, this.mockAgreementTransformer);
+
+    Optional<SettlementMission> settlementMissionOptional = service.updateMission(35L, testTradeAgreement);
+    assertEquals((Long) 35L, settlementMissionOptional.get().getId());
+  }
+
+  @Test
+  public void testMissionExists() {
+
+    given(this.mockSettlementMissionRpsy.exists(35L))
+        .willReturn(true);
+
+    SettlementService service =
+        new SettlementService(this.mockSettlementMissionRpsy, this.mockAgreementTransformer);
+
+    boolean missionExists = service.missionExists(35L);
+    assertTrue(missionExists);
+  }
+
+  @Test
+  public void testDeleteMission() {
+
+    doNothing().when(this.mockSettlementMissionRpsy).delete(35L);
+
+    SettlementService service =
+        new SettlementService(this.mockSettlementMissionRpsy, this.mockAgreementTransformer);
+
+    service.deleteMission(35L);
   }
 }


### PR DESCRIPTION
The first 5 points of #231.

Demonstrates:
1. Knowledge of JPA (e.g. difference between JPA and Hiberate and Spring Data) via documentation
2. Create (There is already an endpoint to create missions)
3. Update
4. Delete
5. Read (There is already an endpoint to read missions)