### PR TITLE
Update Version of Jackson Jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,13 +153,19 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.7.2</version>
+			<version>2.9.9</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.9.9</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.7.2</version>
+			<version>2.9.9.2</version>
 		</dependency>
 
 		<!-- Enable production-ready features with actuator -->


### PR DESCRIPTION
In order to fix vulnerability version 2.9.9.2 of jackson-databind must be used.  Also the versions of jackson-core and jackson-annotation must match version of jackson-databind.