### PR TITLE
#40 -- set request-success to false for 400s.  400s don't throw an ex…

### DIFF
--- a/src/main/java/org/galatea/starter/utils/Tracer.java
+++ b/src/main/java/org/galatea/starter/utils/Tracer.java
@@ -186,7 +186,6 @@ public class Tracer {
         throws Exception {
       try {
         T result = func.call();
-        addTraceInfo(clz, traceKeyPrefix + "-success", "true");
         return result;
       } catch (Exception err) {
         addTraceInfo(clz, traceKeyPrefix + "-success", "false");

--- a/src/main/java/org/galatea/starter/utils/Tracer.java
+++ b/src/main/java/org/galatea/starter/utils/Tracer.java
@@ -185,8 +185,7 @@ public class Tracer {
     public <T> T runAndTraceSuccess(final String traceKeyPrefix, final Callable<T> func)
         throws Exception {
       try {
-        T result = func.call();
-        return result;
+        return func.call();
       } catch (Exception err) {
         addTraceInfo(clz, traceKeyPrefix + "-success", "false");
         addTraceInfo(clz, traceKeyPrefix + "-error", err.getMessage());

--- a/src/main/java/org/galatea/starter/utils/rest/FuseWebRequestTraceFilter.java
+++ b/src/main/java/org/galatea/starter/utils/rest/FuseWebRequestTraceFilter.java
@@ -114,10 +114,16 @@ public class FuseWebRequestTraceFilter extends WebRequestTraceFilter {
       Map<String, Object> springTraceInfo = super.getTrace(request);
 
       MutableInt status = new MutableInt(HttpStatus.INTERNAL_SERVER_ERROR.value());
+      final String traceKeyPrefix = "request";
       try {
-        t.runAndTraceSuccess("request", () -> {
+        t.runAndTraceSuccess(traceKeyPrefix, () -> {
           filterChain.doFilter(request, response);
           status.setValue(response.getStatus());
+          if(response.getStatus() < 400) {
+            addTraceInfo(this.getClass(), traceKeyPrefix + "-success", "true");
+          } else {
+            addTraceInfo(this.getClass(), traceKeyPrefix + "-success", "false");
+          }
           return Void.TYPE;
         });
       } finally {

--- a/src/main/java/org/galatea/starter/utils/rest/FuseWebRequestTraceFilter.java
+++ b/src/main/java/org/galatea/starter/utils/rest/FuseWebRequestTraceFilter.java
@@ -119,7 +119,7 @@ public class FuseWebRequestTraceFilter extends WebRequestTraceFilter {
         t.runAndTraceSuccess(traceKeyPrefix, () -> {
           filterChain.doFilter(request, response);
           status.setValue(response.getStatus());
-          if(response.getStatus() < 400) {
+          if (response.getStatus() < 400) {
             addTraceInfo(this.getClass(), traceKeyPrefix + "-success", "true");
           } else {
             addTraceInfo(this.getClass(), traceKeyPrefix + "-success", "false");


### PR DESCRIPTION
#40 -- set request-success to false for 400s. 400s don't throw an exception so we have to do an explicit check against the http response object in order to get the right value populated in the trace.