### PR TITLE
#279 log to console in addition to logging to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This readme will contain an index to features and their location in code.
   - Select the "Perform the selected actions on save", "Format source code", "Format edited lines", and "Organize imports" options
 - Run stuff:
   - src/main/java/org/galatea/starter/Application.java -> r-click -> run as Java Application.  This will start a jms listener and REST services.  Note, there is an eclipse .launch file provided which configures some VM and Program args.  
-    - Note, logs will be written to C:/Users/your-user-name/logs and will not be written to stdout as is generally appropriate in a deployed setting.
+    - Note, logs will be written to C:/Users/your-user-name/logs as well as being written to stdout.
     - Note, the server port on which the application runs is set via program argument in the run configuration, --server.port=8080.  If you need to change which port to run on, change the argument in the run configuration.
   - src/test/java/org/galatea/starter/UnitTestRunner.java -> r-click -> run as Junit test to run just the unit tests.
   - src/test/java/org/galatea/starter/AllTestRunner.java -> r-click -> run as Junit test to run the unit and integration tests.
@@ -49,7 +49,7 @@ This readme will contain an index to features and their location in code.
 - Run stuff:
   - FUSE has some IntelliJ run configurations checked into the repository under .idea/runConfigurations. These run configs should be automatically imported by IntelliJ and listed in a drop-down in the top-right of the screen. Next to the drop-down are buttons to run the selected run configuration, to run in debug mode, or to run with coverage measurement. If the run configs are automatically found, they may need to be manually imported.
   - To run FUSE, use the "Application" run config.  This will start a jms listener and REST services.
-    - Note, logs will be written to <project_directory>/logs and will not be written to stdout as is generally appropriate in a cloud-deployed setting. See Logging section for more info.
+    - Note, logs will be written to <project_directory>/logs as well as being written to stdout.
     - Note, the server port on which the application runs is set via program argument in the run configuration, --server.port=8080.  If you need to change which port to run on, change the argument in the run configuration.
   - To run unit tests, use the "Unit Tests" run config. See Testing section below for more info.
   - To validate code style, use the "Checkstyle" run config.

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -31,7 +31,14 @@ Configuration:
 
 # Create some appenders
   Appenders:
-  
+
+    # Log to console.
+    Console:
+      name: Console
+      target: SYSTEM_OUT
+      PatternLayout:
+        Pattern: "%d{yyyy.MM.dd HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %X{internal-request-id}%X{external-request-id}%msg%n%xThrowable{separator(|)}"
+
     # Log to a specific file.
     # For details of configuration options, see: https://logging.apache.org/log4j/2.x/manual/appenders.html#RollingFileAppender
     RollingFile:
@@ -134,7 +141,8 @@ Configuration:
       level: info
       AppenderRef:
         - ref: AsyncAppender
-        
+        - ref: Console
+
     Logger:
       # Let's send all messages from a specific logger somewhere else as well
       - name: org.galatea.starter.entrypoint.SettlementRestController


### PR DESCRIPTION
update log4j2.yml to log to console in addition to logging to file.  log4j2-stdout.yml will still log to console only

Resolves #279 