### PR TITLE
341 restore CI builds including integration tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,15 +4,14 @@ documentation of the available features.
 
 We want the following behavior:
 - Pushes to a branch trigger build and sonar-scan (branch-build.yml)
-- PRs and updates thereto trigger build and sonar-scan (pr-build.yml)
-- PRs and updates thereto additionally trigger build, deployment to cloud foundry, execution of 
-integration tests, and shutdown of the cloud foundry deployment
+- PRs and updates thereto trigger build and sonar-scan, and additionally build, deployment to cloud 
+foundry, execution of integration tests, and shutdown of the cloud foundry deployment (pr-build.yml)
 - Pushes to develop or main additionally trigger build, deployment to cloud foundry, execution of 
-integration tests, and shutdown of the cloud foundry deployment
+integration tests, and shutdown of the cloud foundry deployment (develop-build.yml)
 
 We have defined branch protection rules requiring success in the above workflows prior to merge to 
 develop or main.  
-
+ 
 Note:
 - These workflows require manual intervention from an admin to run on PRs from forks or from Dependabot
 (which is an automatic dependency update tool). See 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,19 @@
+We are (as of 20211221) supporting continuous integration via GitHub actions/workflows, 
+which are defined in this folder. See https://docs.github.com/en/actions for full 
+documentation of the available features.
+
+We want the following behavior:
+- Pushes to a branch trigger build and sonar-scan (branch-build.yml)
+- PRs and updates thereto trigger build and sonar-scan (pr-build.yml)
+- PRs and updates thereto additionally trigger build, deployment to cloud foundry, execution of 
+integration tests, and shutdown of the cloud foundry deployment
+- Pushes to develop or main additionally trigger build, deployment to cloud foundry, execution of 
+integration tests, and shutdown of the cloud foundry deployment
+
+We have defined branch protection rules requiring success in the above workflows prior to merge to 
+develop or main.  
+
+Note:
+- These workflows require manual intervention from an admin to run on PRs from forks or from Dependabot
+(which is an automatic dependency update tool). See 
+https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull-request-events-for-forked-repositories

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,4 +4,4 @@ on:
   push
 jobs:
   build:
-    uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml
+    uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml@46e5d70fd988169772dfafd2c59d920c5aced0cb

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -31,4 +31,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java
+        run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,4 +4,7 @@ on:
   push
 jobs:
   build:
-    uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml@46e5d70fd988169772dfafd2c59d920c5aced0cb
+    uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml@5eb53e5072ab55ea8892751325400cddb54c452a
+    with:
+      secrets:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -1,34 +1,7 @@
 name: Branch Build
-# Note: this differs only in name and triggers ("on") from pr-build.yml, since we want to build and
-# sonar-scan branches and prs equivalently.  Any changes to this file should also be reflected there
+
 on:
   push
 jobs:
   build:
-    name: Branch Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Maven packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java
+    uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -5,6 +5,5 @@ on:
 jobs:
   build:
     uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml@5eb53e5072ab55ea8892751325400cddb54c452a
-    with:
-      secrets:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -1,15 +1,11 @@
-name: Build
+name: Branch Build
+# Note: this differs only in name and triggers ("on") from pr-build.yml, since we want to build and
+# sonar-scan branches and prs equivalently.  Any changes to this file should also be reflected there
 on:
-  push:
-    branches:
-      - master
-      - develop
-      - feature/341_github-ci
-  pull_request:
-    types: [opened, synchronize, reopened]
+  push
 jobs:
   build:
-    name: Build
+    name: Branch Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  workflow_call
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - develop
+      - feature/341_github-ci
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -34,4 +35,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java
+        run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 name: Build
 
 on:
-  workflow_call
+  workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: true
 jobs:
   build:
     name: Build

--- a/.github/workflows/develop-build.yml
+++ b/.github/workflows/develop-build.yml
@@ -7,7 +7,7 @@ on:
       - main
 jobs:
   integration-tests:
-    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@de09277d9bd4cd62123b81cf8965d9837ff1004f
+    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@a1a0aaf463ffc9daa4773b6e42a27b5cb7d582bb
     secrets:
       IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
       IBM_CLOUD_CF_API: ${{ secrets.IBM_CLOUD_CF_API }}

--- a/.github/workflows/develop-build.yml
+++ b/.github/workflows/develop-build.yml
@@ -7,10 +7,9 @@ on:
       - main
 jobs:
   integration-tests:
-    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@5eb53e5072ab55ea8892751325400cddb54c452a
-    with:
-      secrets:
-        IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
-        IBM_CLOUD_CF_API: ${{ secrets.IBM_CLOUD_CF_API }}
-        IBM_CLOUD_CF_ORG: ${{ secrets.IBM_CLOUD_CF_ORG }}
-        IBM_CLOUD_CF_SPACE: ${{ secrets.IBM_CLOUD_CF_SPACE }}
+    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@de09277d9bd4cd62123b81cf8965d9837ff1004f
+    secrets:
+      IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
+      IBM_CLOUD_CF_API: ${{ secrets.IBM_CLOUD_CF_API }}
+      IBM_CLOUD_CF_ORG: ${{ secrets.IBM_CLOUD_CF_ORG }}
+      IBM_CLOUD_CF_SPACE: ${{ secrets.IBM_CLOUD_CF_SPACE }}

--- a/.github/workflows/develop-build.yml
+++ b/.github/workflows/develop-build.yml
@@ -1,14 +1,11 @@
-name: PR Build
+name: Develop Build
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - develop
+      - main
 jobs:
-  build:
-    uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml@5eb53e5072ab55ea8892751325400cddb54c452a
-    with:
-      secrets:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   integration-tests:
     uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@5eb53e5072ab55ea8892751325400cddb54c452a
     with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,7 +9,7 @@ jobs:
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   integration-tests:
-    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@de09277d9bd4cd62123b81cf8965d9837ff1004f
+    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@a1a0aaf463ffc9daa4773b6e42a27b5cb7d582bb
     secrets:
       IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
       IBM_CLOUD_CF_API: ${{ secrets.IBM_CLOUD_CF_API }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,35 +1,10 @@
 name: PR Build
-# Note: this differs only in name and triggers ("on") from branch-build.yml, since we want to build and
-# sonar-scan branches and prs equivalently.  Any changes to this file should also be reflected there
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
   build:
-    name: PR Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Maven packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java
+    uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml
+  integration-tests:
+    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,35 @@
+name: PR Build
+# Note: this differs only in name and triggers ("on") from branch-build.yml, since we want to build and
+# sonar-scan branches and prs equivalently.  Any changes to this file should also be reflected there
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: PR Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,6 +5,6 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
-    uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml
+    uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml@46e5d70fd988169772dfafd2c59d920c5aced0cb
   integration-tests:
-    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml
+    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@46e5d70fd988169772dfafd2c59d920c5aced0cb

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -6,14 +6,12 @@ on:
 jobs:
   build:
     uses: galatea-associates/fuse-starter-java/.github/workflows/build.yml@5eb53e5072ab55ea8892751325400cddb54c452a
-    with:
-      secrets:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   integration-tests:
-    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@5eb53e5072ab55ea8892751325400cddb54c452a
-    with:
-      secrets:
-        IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
-        IBM_CLOUD_CF_API: ${{ secrets.IBM_CLOUD_CF_API }}
-        IBM_CLOUD_CF_ORG: ${{ secrets.IBM_CLOUD_CF_ORG }}
-        IBM_CLOUD_CF_SPACE: ${{ secrets.IBM_CLOUD_CF_SPACE }}
+    uses: galatea-associates/fuse-starter-java/.github/workflows/run-integration-tests.yml@de09277d9bd4cd62123b81cf8965d9837ff1004f
+    secrets:
+      IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
+      IBM_CLOUD_CF_API: ${{ secrets.IBM_CLOUD_CF_API }}
+      IBM_CLOUD_CF_ORG: ${{ secrets.IBM_CLOUD_CF_ORG }}
+      IBM_CLOUD_CF_SPACE: ${{ secrets.IBM_CLOUD_CF_SPACE }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java
+        run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=galatea-associates_fuse-starter-java

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build artifact
-        run: mvn package -DskipTests # how do we make the artifact available later?
+        run: mvn package -DskipTests
       # - name: Update manifest file (env.GIT_COMMIT)
       - name: Deploy
         uses: IBM/cloudfoundry-deploy@v2.1
@@ -31,8 +31,8 @@ jobs:
           IBM_CLOUD_CF_ORG: ${{ secrets.IBM_CLOUD_CF_ORG }}
           IBM_CLOUD_CF_SPACE: ${{ secrets.IBM_CLOUD_CF_SPACE }}
           APP_MANIFEST_FILE: manifest-integration-tests.yml
-      # - name: Run integration tests
-      # - name: Run performance tests
+      - name: Run integration tests
+        run: mvn verify -Dskip.surefire.tests -Dfuse.sandbox.url=http://fuse-rest-dev-gitcommit.us-east.mybluemix.net
+      - name: Run performance tests
+        echo "performance tests are not yet implemented"
       # - name: Shutdown
-
-# why isn't git acknowledging changes here?

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,10 +1,14 @@
-name: Test IBM cloud deploy
+name: Deploy and Integration Test
 concurrency: ibm-cloud
 on:
-  push # todo only for develop and main, and prs
+  workflow-call
+  push:
+    branches:
+      - develop
+      - main
 jobs:
-  build-and-deploy:
-    name: Build and Deploy
+  build-deploy-and-test:
+    name: Build, Deploy, and Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build artifact
         run: mvn package -DskipTests
-      # - name: Update manifest file (env.GIT_COMMIT)
+      # - name: Update manifest file (env.GIT_COMMIT) 
       - name: Deploy
         uses: IBM/cloudfoundry-deploy@v2.1
         with:
@@ -35,4 +35,6 @@ jobs:
         run: mvn verify -Dskip.surefire.tests -Dfuse.sandbox.url=http://fuse-rest-dev-gitcommit.us-east.mybluemix.net
       - name: Run performance tests
         run: echo "performance tests are not yet implemented"
-      # - name: Shutdown
+      - name: Shutdown
+        if: ${{ always() }} # shutdown the cf instance whether or not testing succeeded
+        run: ibmcloud cf stop fuse-rest-dev-GIT_COMMIT

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -2,10 +2,15 @@ name: Deploy and Integration Test
 concurrency: ibm-cloud
 on:
   workflow-call:
-  push:
-    branches:
-      - develop
-      - main
+    secrets:
+      IBM_CLOUD_API_KEY:
+        required: true
+      IBM_CLOUD_CF_API:
+        required: true
+      IBM_CLOUD_CF_ORG:
+        required: true
+      IBM_CLOUD_CF_SPACE:
+        required: true
 jobs:
   build-deploy-and-test:
     name: Build, Deploy, and Test

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,5 +1,5 @@
 name: Test IBM cloud deploy
-concurrency: ibm-cloud # probably actually want this at the job lvl?
+concurrency: ibm-cloud
 on:
   push # todo only for develop and main, and prs
 jobs:
@@ -40,4 +40,4 @@ jobs:
         run: |
           ibmcloud cf stop fuse-rest-dev-GIT_COMMIT
           ibmcloud cf delete fuse-rest-dev-GIT_COMMIT -r -f
-          ibmcloud cf logout
+          ibmcloud logout

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,7 +1,7 @@
 name: Deploy and Integration Test
 concurrency: ibm-cloud
 on:
-  workflow-call
+  workflow-call:
   push:
     branches:
       - develop

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,0 +1,38 @@
+name: Test IBM cloud deploy
+concurrency: ibm-cloud # probably actually want this at the job lvl?
+on:
+  push # todo only for develop and main, and prs
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build artifact
+        run: mvn package -DskipTests # how do we make the artifact available later?
+      # - name: Update manifest file (env.GIT_COMMIT)
+      - name: Deploy
+        uses: IBM/cloudfoundry-deploy@v2.1
+        with:
+          IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
+          IBM_CLOUD_CF_API: ${{ secrets.IBM_CLOUD_CF_API }}
+          IBM_CLOUD_CF_ORG: ${{ secrets.IBM_CLOUD_CF_ORG }}
+          IBM_CLOUD_CF_SPACE: ${{ secrets.IBM_CLOUD_CF_SPACE }}
+          APP_MANIFEST_FILE: manifest-integration-tests.yml
+      # - name: Run integration tests
+      # - name: Run performance tests
+      # - name: Shutdown
+
+# why isn't git acknowledging changes here?

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -37,6 +37,7 @@ jobs:
         run: echo "performance tests are not yet implemented"
       - name: Shutdown
         if: ${{ always() }} # shutdown the cf instance whether or not testing succeeded
-        run: ibmcloud cf stop fuse-rest-dev-GIT_COMMIT
+        run: |
+          ibmcloud cf stop fuse-rest-dev-GIT_COMMIT
           ibmcloud cf delete fuse-rest-dev-GIT_COMMIT -r -f
-          ibmcloud cf logout 
+          ibmcloud cf logout

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Run integration tests
         run: mvn verify -Dskip.surefire.tests -Dfuse.sandbox.url=http://fuse-rest-dev-gitcommit.us-east.mybluemix.net
       - name: Run performance tests
-        echo "performance tests are not yet implemented"
+        run: echo "performance tests are not yet implemented"
       # - name: Shutdown

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,7 +1,7 @@
 name: Deploy and Integration Test
 
 on:
-  workflow-call:
+  workflow_call:
     secrets:
       IBM_CLOUD_API_KEY:
         required: true
@@ -11,6 +11,7 @@ on:
         required: true
       IBM_CLOUD_CF_SPACE:
         required: true
+
 jobs:
   build-deploy-and-test:
     name: Build, Deploy, and Test

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,5 +1,5 @@
 name: Deploy and Integration Test
-concurrency: ibm-cloud
+
 on:
   workflow-call:
     secrets:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build artifact
         run: mvn package -DskipTests
-      # - name: Update manifest file (env.GIT_COMMIT) 
+      # - name: Update manifest file (env.GIT_COMMIT)
       - name: Deploy
         uses: IBM/cloudfoundry-deploy@v2.1
         with:
@@ -38,3 +38,5 @@ jobs:
       - name: Shutdown
         if: ${{ always() }} # shutdown the cf instance whether or not testing succeeded
         run: ibmcloud cf stop fuse-rest-dev-GIT_COMMIT
+          ibmcloud cf delete fuse-rest-dev-GIT_COMMIT -r -f
+          ibmcloud cf logout 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ We use this branching model in fuse-starter-java:  http://nvie.com/posts/a-succe
 - Feature branches should be created under feature/
 - Release candidate branches should be created under release/
 - Develop is the main development branch
-- Master should mirror what is running in "production"
+- Main should mirror what is running in "production"
 
 ## SonarQube integration
 - Sonar: https://sonarcloud.io/dashboard?id=org.galatea%3Afuse-starter-java (can login using GitHub account)

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.0.RELEASE</version>
+		<version>2.6.2</version>
 	</parent>
 
 	<dependencies>
@@ -67,14 +67,14 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
-			<version>2.0.1.RELEASE</version>
+			<version>3.1.0</version>
 		</dependency>
 
 		<!--Spring Cloud Sleuth for distributed log tracing-->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-sleuth</artifactId>
-			<version>2.2.1.RELEASE</version>
+			<version>3.1.0</version>
 		</dependency>
 
 		<!-- Required for log4j to process log4j2.yml -->
@@ -83,7 +83,6 @@
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
 		</dependency>
-
 
 		<!-- Use spring-aop and aspectj for our aspects -->
 		<dependency>
@@ -99,16 +98,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-activemq</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.activemq</groupId>
-			<artifactId>activemq-broker</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<!-- Spring boot web for rest services -->
@@ -131,28 +120,22 @@
 
 		<!-- SWAGGER for API documentation -->
 		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger2</artifactId>
-			<version>2.9.2</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger-ui</artifactId>
-			<version>2.9.2</version>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.6.2</version>
 		</dependency>
 
 		<!-- Web content negotiation -->
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.5.1</version>
+			<version>3.19.1</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.googlecode.protobuf-java-format</groupId>
-			<artifactId>protobuf-java-format</artifactId>
-			<version>1.4</version>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java-util</artifactId>
+			<version>3.19.1</version>
 		</dependency>
 
 		<dependency>
@@ -164,25 +147,25 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-csv</artifactId>
-			<version>2.8.8</version>
+			<version>2.13.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.9.9</version>
+			<version>2.13.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.9.9</version>
+			<version>2.13.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.10.8</version>
+			<version>2.13.1</version>
 		</dependency>
 
 		<!-- JAXB - converting between POJOs and XML -->
@@ -255,9 +238,14 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-			<version>2.0.1.Final</version>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>31.0.1-jre</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 
 		<!-- Excel spreadsheet reading and writing -->
@@ -282,7 +270,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
-			<version>5.1.2.RELEASE</version>
+			<version>5.3.14</version>
 		</dependency>
 
 		<!-- Support for Ehcache and others -->
@@ -295,12 +283,12 @@
     <dependency>
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-core</artifactId>
-      <version>9.5.1</version>
+      <version>11.7</version>
     </dependency>
     <dependency>
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-jackson</artifactId>
-      <version>9.5.1</version>
+      <version>11.7</version>
     </dependency>
 
 		<!-- Testing dependencies -->
@@ -320,7 +308,7 @@
 			<artifactId>spring-cloud-contract-wiremock</artifactId>
 			<groupId>org.springframework.cloud</groupId>
 			<scope>test</scope>
-			<version>2.0.1.RELEASE</version>
+			<version>3.1.0</version>
 		</dependency>
 		<!-- Useful for waiting for an async task to complete -->
 		<dependency>
@@ -332,7 +320,7 @@
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>spring-mock-mvc</artifactId>
-			<version>3.3.0</version>
+			<version>4.4.0</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- Allows us to parameterize tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -335,8 +335,16 @@
 			<groupId>com.googlecode.junit-toolbox</groupId>
 			<artifactId>junit-toolbox</artifactId>
 			<version>2.2</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- avoid needing to upgrade all tests to junit 5 immediately -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<extensions>
 			<extension>

--- a/src/main/java/org/galatea/starter/JmsConfig.java
+++ b/src/main/java/org/galatea/starter/JmsConfig.java
@@ -1,5 +1,6 @@
 package org.galatea.starter;
 
+import java.util.List;
 import java.util.function.BiConsumer;
 import javax.jms.ConnectionFactory;
 import javax.jms.Message;
@@ -13,8 +14,10 @@ import org.springframework.jms.annotation.JmsListenerConfigurer;
 import org.springframework.jms.config.JmsListenerContainerFactory;
 import org.springframework.jms.config.JmsListenerEndpointRegistrar;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
+import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.converter.ProtobufMessageConverter;
 import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
 
@@ -37,7 +40,8 @@ public class JmsConfig implements JmsListenerConfigurer {
    */
   @Bean
   public MessageConverter jacksonJmsMessageConverter() {
-    return new MappingJackson2MessageConverter();
+    return new CompositeMessageConverter(
+        List.of(new MappingJackson2MessageConverter(), new ProtobufMessageConverter()));
   }
 
   /**

--- a/src/main/java/org/galatea/starter/SwaggerConfig.java
+++ b/src/main/java/org/galatea/starter/SwaggerConfig.java
@@ -1,30 +1,13 @@
 package org.galatea.starter;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
 
 @Configuration
-@EnableSwagger2
 // see https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api section 4.2 for
 // configuring w/o Spring Boot
 public class SwaggerConfig implements WebMvcConfigurer {
-
-  /**
-   * Sets configuration for Swagger.
-   */
-  @Bean
-  public Docket api() {
-    return new Docket(DocumentationType.SWAGGER_2).select().apis(RequestHandlerSelectors.any())
-        .paths(PathSelectors.any()).build();
-  }
 
   // the documentation says this shouldn't be necessary, but swagger-ui.html wasn't available
   // without it...

--- a/src/main/java/org/galatea/starter/entrypoint/SettlementJmsListener.java
+++ b/src/main/java/org/galatea/starter/entrypoint/SettlementJmsListener.java
@@ -6,6 +6,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.galatea.starter.domain.TradeAgreement;
+import org.galatea.starter.entrypoint.messagecontracts.ProtobufMessages.TradeAgreementProtoMessage;
 import org.galatea.starter.entrypoint.messagecontracts.TradeAgreementMessage;
 import org.galatea.starter.service.SettlementService;
 import org.galatea.starter.utils.translation.ITranslator;
@@ -21,7 +22,7 @@ public class SettlementJmsListener {
   protected SettlementService settlementService;
 
   @NonNull
-  protected ITranslator<byte[], TradeAgreement> tradeAgreementProtoTranslator;
+  protected ITranslator<TradeAgreementProtoMessage, TradeAgreement> tradeAgreementProtoTranslator;
 
   @NonNull
   protected ITranslator<TradeAgreementMessage, TradeAgreement> tradeAgreementMessageTranslator;
@@ -44,7 +45,7 @@ public class SettlementJmsListener {
    */
   @JmsListener(destination = "${jms.agreement-queue-proto}",
       concurrency = "${jms.listener-concurrency}")
-  public void settleAgreementProto(final byte[] message) {
+  public void settleAgreementProto(final TradeAgreementProtoMessage message) {
     log.info("Received message. Translating.");
     TradeAgreement agreement = tradeAgreementProtoTranslator.translate(message);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,12 @@ spring:
    jpa:
       hibernate:
          ddl-auto: update
-      database-platform: org.hibernate.dialect.MySQL5Dialect
+      database-platform: org.hibernate.dialect.H2Dialect
+   activemq:
+      packages:
+         # ideally this would be something more precise, see comment in
+         # SettlementJmsListenerTest.testSettleOneAgreementProto()
+         trusted: com.google.protobuf,org.galatea.starter.entrypoint.messagecontracts
 
 mvc:
    settleMissionPath: /settlementEngine

--- a/src/test/java/org/galatea/starter/entrypoint/HalRestControllerIntegrationTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/HalRestControllerIntegrationTest.java
@@ -34,7 +34,7 @@ public class HalRestControllerIntegrationTest extends ASpringTest {
     }
 
     FuseServer fuseServer =
-        Feign.builder().decoder(new JacksonDecoder()).encoder(new JacksonEncoder())
+        Feign.builder().encoder(new JacksonEncoder())
             .target(FuseServer.class, fuseHostName);
 
     String halResponse = fuseServer.halEndpoint("coin-flip");
@@ -51,7 +51,7 @@ public class HalRestControllerIntegrationTest extends ASpringTest {
     }
 
     FuseServer fuseServer =
-        Feign.builder().decoder(new JacksonDecoder()).encoder(new JacksonEncoder())
+        Feign.builder().encoder(new JacksonEncoder())
             .target(FuseServer.class, fuseHostName);
 
     String expResult = "derp!";

--- a/src/test/java/org/galatea/starter/entrypoint/HalRestControllerIntegrationTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/HalRestControllerIntegrationTest.java
@@ -21,7 +21,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @Slf4j
 @Category(org.galatea.starter.IntegrationTestCategory.class)
 @SpringBootTest
-@Ignore
 public class HalRestControllerIntegrationTest extends ASpringTest {
 
   @Value("${fuse-host.url}")

--- a/src/test/java/org/galatea/starter/entrypoint/SettlementJmsListenerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/SettlementJmsListenerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import javax.jms.BytesMessage;
 import javax.jms.TextMessage;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/org/galatea/starter/entrypoint/SettlementJmsListenerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/SettlementJmsListenerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import javax.jms.BytesMessage;
 import javax.jms.TextMessage;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
@@ -85,7 +86,11 @@ public class SettlementJmsListenerTest extends ASpringTest {
     List<TradeAgreement> agreements = Collections.singletonList(agreement);
     log.info("Agreement objects that the service will expect {}", agreements);
 
-    jmsTemplate.convertAndSend(protoQueueName, message.toByteArray());
+    // We would ideally (and did in an earlier version) not send just the raw object, but with
+    // the upgrade to spring-boot 2.6.2 (or probably one of its dependencies) the JmsListener can
+    // no longer read the body from the result of
+    // jmsTemplate.convertAndSend(protoQueueName, message.toByteArray())
+    jmsTemplate.convertAndSend(protoQueueName, message);
 
     verify(mockSettlementService, timeout(10000)).spawnMissions(agreements);
   }

--- a/src/test/java/org/galatea/starter/entrypoint/SettlementRestControllerIntegrationTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/SettlementRestControllerIntegrationTest.java
@@ -35,9 +35,7 @@ import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter;
 @RequiredArgsConstructor
 @Slf4j
 @Category(org.galatea.starter.IntegrationTestCategory.class)
-@Ignore
 public class SettlementRestControllerIntegrationTest {
-
 
   @Value("${fuse-host.url}")
   private String FuseHostName;

--- a/src/test/java/org/galatea/starter/entrypoint/SettlementRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/SettlementRestControllerTest.java
@@ -49,13 +49,13 @@ import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -301,7 +301,7 @@ public class SettlementRestControllerTest
         .then()
         .log().ifValidationFails()
         .statusCode(HttpStatus.OK.value())
-        .content(is(objectMapper.writeValueAsString(new SettlementMissionList(missions))));
+        .body(is(objectMapper.writeValueAsString(new SettlementMissionList(missions))));
   }
 
   @Test
@@ -375,18 +375,17 @@ public class SettlementRestControllerTest
 
     byte[] expectedXlsx = readBytes("SettlementMissions.xlsx");
 
-
     MockMvcResponse response =
-    given()
-        .log().ifValidationFails()
-        .when()
-        .get("/settlementEngine/missions?ids=1,2&format=xlsx&requestId=1234")
-        .then()
-        .log().ifValidationFails()
-        .statusCode(HttpStatus.OK.value())
-        .contentType("application/vnd.ms-excel")
-        .extract()
-        .response();
+        given()
+            .log().ifValidationFails()
+            .when()
+            .get("/settlementEngine/missions?ids=1,2&format=xlsx&requestId=1234")
+            .then()
+            .log().ifValidationFails()
+            .statusCode(HttpStatus.OK.value())
+            .contentType("application/vnd.ms-excel")
+            .extract()
+            .response();
 
     // Directly comparing the spreadsheet bytes fails even when the expected spreadsheet appears to
     // be an exact copy of the actual result, so instead compare the spreadsheet contents logically
@@ -526,9 +525,9 @@ public class SettlementRestControllerTest
   static class PropertyConfig {
 
     @Bean
-    PropertyPlaceholderConfigurer propertyPlaceholderConfigurer() {
-      PropertyPlaceholderConfigurer propertyPlaceholderConfigurer =
-          new PropertyPlaceholderConfigurer();
+    PropertySourcesPlaceholderConfigurer propertyPlaceholderConfigurer() {
+      PropertySourcesPlaceholderConfigurer propertyPlaceholderConfigurer =
+          new PropertySourcesPlaceholderConfigurer();
       propertyPlaceholderConfigurer.setLocation(new ClassPathResource("application.properties"));
       return propertyPlaceholderConfigurer;
     }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,4 +1,5 @@
 fuse-host.url:https://fuse-rest-dev.cfapps.io
+wiremock.server.port:8099
 cache-config: ehcache-test.xml
 mvc.settleMissionPath:/settlementEngine
 mvc.updateMissionPath:/settlementEngine/mission/


### PR DESCRIPTION
- Trigger jacoco agent along with sonar scan to record test coverage
- Upgrade log4j (via spring-boot, which meant a bunch of other stuff as well) to resolve vulnerability prior to experimenting with deployments
- Set up continuous integration via GitHub actions and restore integration testing phase via ibmcloud cloud foundry